### PR TITLE
Improved programming languages regular expression

### DIFF
--- a/get-details.coffee
+++ b/get-details.coffee
@@ -20,7 +20,7 @@ getStats = (html, url) ->
     name: byProp('name').text().trim()
     login: byProp('additionalName').text().trim()
     location: byProp('homeLocation').text().trim()
-    language: (/\sin ([\w-]+)/.exec(pageDesc)?[1] ? '')
+    language: (/\sin ([\w-+#\s\(\)]+)/.exec(pageDesc)?[1] ? '')
     gravatar: byProp('image').attr('href')
     followers: getFollowers()
     organizations: $('#site-container > div > div > div.column.one-fourth.vcard > div.clearfix > a').toArray().map(getOrgName)


### PR DESCRIPTION
Fixed regular expression to match some languages:
- '+' ie C++
- '#' ie C#, F#
- ' ' ie Game Maker Language
- '(', ')' for Graphviz (DOT)

It should match now all languages from [linguist/languages.yml](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml)
