### PR TITLE
Fixing broken scripts

### DIFF
--- a/format-users.coffee
+++ b/format-users.coffee
@@ -53,7 +53,7 @@ stats2markdown = (datafile, mdfile, title) ->
     .slice(0, #{maxNumber})
   ```
 
-  Made with data mining of GitHub.com ([raw data](https://gist.github.com/4524946), [script](https://github.com/paulmillr/top-github-users)) by [@paulmillr](https://github.com/paulmillr) with contribs of [@lifesinger](https://github.com/lifesinger). Updated once per week.
+  Made with data mining of GitHub.com ([raw data](https://gist.github.com/4524946), [script](https://github.com/paulmillr/top-github-users)) by [@paulmillr](https://github.com/paulmillr) with contribs of [@lifesinger](https://github.com/lifesinger) and [@ahmetalpbalkan](https://github.com/ahmetalpbalkan). Updated once per week.
 
   <table cellspacing="0"><thead>
   <th scope="col">#</th>

--- a/format-users.coffee
+++ b/format-users.coffee
@@ -59,7 +59,7 @@ stats2markdown = (datafile, mdfile, title) ->
   <th scope="col">#</th>
   <th scope="col">User</th>
   <th scope="col">Contribs</th>
-  <th scope="col">Language</th>
+  <!-- Language currently disabled: GitHub returns 'Shell' for most users <th scope="col">Language</th> -->
   <th scope="col">Location</th>
   <th scope="col" width="30"></th>
   </thead><tbody>\n
@@ -72,7 +72,7 @@ stats2markdown = (datafile, mdfile, title) ->
       <th scope="row">##{index + 1}</th>
       <td><a href="https://github.com/#{stat.login}">#{stat.login}</a>#{if stat.name then ' (' + stat.name + ')' else ''}</td>
       <td>#{stat.contributions}</td>
-      <td>#{stat.language}</td>
+      <!-- <td>#{stat.language}</td> -->
       <td>#{stat.location}</td>
       <td><img width="30" height="30" src="#{stat.gravatar.replace('?s=400', '?s=30')}"></td>
     </tr>
@@ -83,7 +83,6 @@ stats2markdown = (datafile, mdfile, title) ->
   out += """## Top 10 users from this list by other metrics:
 
 * **Followers:** #{top stats, 'followers', 'thousands'}
-* **Current contributions streak:** #{top stats, 'contributionsCurrentStreak'}
 * **Organisations:** #{top stats, 'organizations', 'list'}
   """
 

--- a/format-users.coffee
+++ b/format-users.coffee
@@ -61,7 +61,7 @@ stats2markdown = (datafile, mdfile, title) ->
   <th scope="col">Contribs</th>
   <!-- Language currently disabled: GitHub returns 'Shell' for most users <th scope="col">Language</th> -->
   <th scope="col">Location</th>
-  <th scope="col" width="30"></th>
+  <th scope="col" width="30">Picture</th>
   </thead><tbody>\n
   """
 

--- a/get-details.coffee
+++ b/get-details.coffee
@@ -23,10 +23,8 @@ getStats = (html, url) ->
     language: (/\sin ([\w-+#\s\(\)]+)/.exec(pageDesc)?[1] ? '')
     gravatar: byProp('image').attr('href')
     followers: getFollowers()
-    organizations: $('#site-container > div > div > div.column.one-fourth.vcard > div.clearfix > a').toArray().map(getOrgName)
-    contributions: getInt $('#contributions-calendar > div:nth-child(3) > span.contrib-number').text()
-    contributionsStreak: getInt $('#contributions-calendar > div:nth-child(4) > span.contrib-number').text()
-    contributionsCurrentStreak: getInt $('#contributions-calendar > div:nth-child(5) > span.contrib-number').text()
+    organizations: $('#js-pjax-container > div > div > div.column.one-fourth.vcard > div.clearfix > a').toArray().map(getOrgName)
+    contributions: getInt $('#js-pjax-container > div > div > div.column.three-fourths > div.js-repo-filter.position-relative > div > div.boxed-group.flush > h3').text().trim().split(' ')[0]
 
   stats[userStats.login] = userStats
   userStats

--- a/get-users.coffee
+++ b/get-users.coffee
@@ -10,6 +10,7 @@ BANNED = [
   'IonicaBizau'   # Contribution graffiti.
   'scottgonzalez' # Graffiti.
   'AutumnsWind'   # Graffiti.
+  'hintjens'      # Graffiti.
 ]
 
 saveTopLogins = ->


### PR DESCRIPTION
GitHub recently changed their HTML so scraping was broken. These commits fix it.

Several implications:

- GitHub no longer has streaks, so **removed streaks**.
- GitHub returns languages for almost all users as `Shell, JavaScript, and Ruby` in meta=description. (for instance, for me. I never code in those languages.) Looks like a bug. See below for output. So **disabled the language output** as well.
- Increased width of pictures column, they were previously almost invisible.

Output looks good: https://gist.github.com/ahmetalpbalkan/3469b8e652f27cbcfdb9a1e0a2121faa


#### Appendix `raw/github-languages-stats.json`

```json

{
  "Total": 963,
  "Shell": 855,
  "JavaScript": 54,
  "ActionScript": 9,
  "Ada": 6,
  "ApacheConf": 5,
  "ABAP": 5,
  "Python": 4,
  "Java": 3,
  "Ruby": 3,
  "ANTLR": 3,
  "AppleScript": 2,
  "Ruby and Objective-C": 2,
  "Go": 2,
  "AGS Script": 1,
  "Assembly": 1,
  "JavaScript and Ruby": 1,
  "JavaScript and HTML": 1,
  "Java and HTML": 1,
  "C++": 1,
  "C": 1
}
```