### PR TITLE
Move coffeescript to devDeps & add package-lock.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM node:6
 
 COPY . /app
 WORKDIR /app
-RUN ["npm", "install", "-g", "coffee-script"]
 RUN ["npm", "install"]
 
 VOLUME /app/formatted

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+PATH := ./node_modules/.bin:$(PATH)
 all: get format
 get: 1 2
 format: 3

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
     "cheerio": "~0.10.5",
     "superagent": "~0.14.0",
     "batch": "~0.3.2"
+  },
+  "devDependencies": {
+    "coffeescript": "^1.12.7"
   }
 }


### PR DESCRIPTION
This makes it easier to run overall by not relying on any system-wide deps.