### PR TITLE
Bump cheerio, update html parsing, modify query

### DIFF
--- a/get-details.coffee
+++ b/get-details.coffee
@@ -11,7 +11,7 @@ getStats = (html, url) ->
   getOrgName = (item) -> $(item).attr('aria-label')
   login = byProp('additionalName').text().trim()
   getFollowers = ->
-    text = $("a[href=\"/#{login}?tab=followers\"] > .Counter").text().trim()
+    text = $("a[href=\"https://github.com/#{login}?tab=followers\"] > .text-bold").text().trim()
     multiplier = if text.indexOf('k') > 0 then 1000 else 1
     (parseFloat text) * multiplier
 
@@ -24,7 +24,7 @@ getStats = (html, url) ->
     language: (/\sin ([\w-+#\s\(\)]+)/.exec(pageDesc)?[1] ? '')
     gravatar: byProp('image').attr('href')
     followers: getFollowers()
-    organizations: $('h2:contains("Organizations") ~ a').toArray().map(getOrgName)
+    organizations: $('.p-org').text().trim()
     contributions: getInt $('div.position-relative > h2.f4.text-normal.mb-2').text().trim().split(' ')[0]
  
   stats[userStats.login] = userStats

--- a/get-users.coffee
+++ b/get-users.coffee
@@ -17,7 +17,7 @@ saveTopLogins = ->
   MIN_FOLLOWERS = 435
   MAX_PAGES = 10
   urls = utils.range(1, MAX_PAGES + 1).map (page) -> [
-      "https://api.github.com/search/users?q=followers:%3E#{MIN_FOLLOWERS}+sort:followers&per_page=100"
+      "https://api.github.com/search/users?q=followers:%3E#{MIN_FOLLOWERS}+sort:followers+type:user&per_page=100"
       "&page=#{page}"
     ].join('')
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "gitHead": "e6a55ed9abd436d3c60323e6cc1d2b3ad6784abb",
   "readmeFilename": "README.md",
   "dependencies": {
-    "cheerio": "~0.10.5",
+    "cheerio": "v1.0.0-rc.12",
     "superagent": "~0.14.0",
     "batch": "~0.3.2"
   }


### PR DESCRIPTION
Bump cheerio so that it's compatible with current html, update html parsing to working with current github profile pages, modify query to exclude organizations so that more users can be considered given that there is a cap on github's search query